### PR TITLE
Runs on vm and fix bugs

### DIFF
--- a/tests/snappi/bgp/test_bgp_rib_in_capacity.py
+++ b/tests/snappi/bgp/test_bgp_rib_in_capacity.py
@@ -6,7 +6,7 @@ from tests.common.fixtures.conn_graph_facts import (                        # no
 import pytest
 
 
-@pytest.mark.parametrize('multipath', [2])
+@pytest.mark.parametrize('multipath', [1])
 @pytest.mark.parametrize('start_value', [1000])
 @pytest.mark.parametrize('step_value', [1000])
 @pytest.mark.parametrize('route_type', ['IPv4'])


### PR DESCRIPTION
test_bgp_rib_in_capacity.py
Change 2 to 1 so the test run using 2 ports.

bgp_convergence_helper.py

- Fix bug Attribute error by replacing  lp.protocol to c_lag.protocol
- The hw result of the test not depend on line rate. The vm cant run at line rate 100, so line rate now 10.
- Now the traffic stops and then the script checks the statistics.
- To run on vm set up the if statement is written. If the set up is vm then disable the EnableDataPlaneEventsRateMonitor

